### PR TITLE
Fix population of url field and cleanup notes field

### DIFF
--- a/src/applePasswords/ApplePasswords.ts
+++ b/src/applePasswords/ApplePasswords.ts
@@ -23,8 +23,10 @@ export class ApplePasswords {
         case BITWARDEN.ItemType.Login: {
           processedCount++
           const login = item.login
-          const hostnames = login.__sameHostnames__?.value ?? [undefined]
-          for (const hostname of hostnames) {
+          // const hostnames = login.__sameHostnames__?.value ?? [undefined]
+          const uris = login.uris ?? []
+          // for (const hostname of hostnames) {
+          for (const uri of uris) {
             const notes = app.serializeCommon(item)
             let name = item.name
             if (login.__sameHostnames__?.needsFix) {
@@ -36,7 +38,7 @@ export class ApplePasswords {
               Username: login.username,
               Password: login.password,
               OTPAuth: login.totp,
-              URL: hostname,
+              URL: uri.uri ? uri.uri : undefined,
               Notes: notes,
             }
             outputs.push(output)

--- a/src/applePasswords/ApplePasswords.ts
+++ b/src/applePasswords/ApplePasswords.ts
@@ -23,9 +23,7 @@ export class ApplePasswords {
         case BITWARDEN.ItemType.Login: {
           processedCount++
           const login = item.login
-          // const hostnames = login.__sameHostnames__?.value ?? [undefined]
           const uris = login.uris ?? []
-          // for (const hostname of hostnames) {
           for (const uri of uris) {
             const notes = app.serializeCommon(item)
             let name = item.name

--- a/src/bitwarden/Bitwarden.ts
+++ b/src/bitwarden/Bitwarden.ts
@@ -367,7 +367,7 @@ export class Bitwarden {
     return uris
       .map((uri) => {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        return `${URI_MATCH_REVERSE[uri.match as any ?? null]} = ${uri.uri}`
+        return `${URI_MATCH_REVERSE[(uri.match as any) ?? null]} = ${uri.uri}`
       })
       .join('\n')
   }

--- a/src/bitwarden/Bitwarden.ts
+++ b/src/bitwarden/Bitwarden.ts
@@ -367,7 +367,7 @@ export class Bitwarden {
     return uris
       .map((uri) => {
         // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        return `${URI_MATCH_REVERSE[uri.match as any]} = ${uri.uri}`
+        return `${URI_MATCH_REVERSE[uri.match as any ?? null]} = ${uri.uri}`
       })
       .join('\n')
   }


### PR DESCRIPTION
This PR address [issue-5](https://github.com/gutenye/password-manager-tools/issues/5) with the following changes:

- Loop through URIs instead of hostnames because login.\_\_same_Hostnames\_\_?.value appears to be falsy, resulting in hostnames always being assign value [undefined].
- Add conditional logic to pass null to URI_MATCH_REVERSE when uri.match is undefined. This prevents undefined from being included in the csv output file's notes column. The uri.match property is not defined in my Bitwarden exports.

I had some issues executing the test because of how ink is required. However, the failures appear unrelated to these changes.